### PR TITLE
✅ Fix Flake8 stylistic failures in new script

### DIFF
--- a/scripts/apply_dev_defaults.py
+++ b/scripts/apply_dev_defaults.py
@@ -1,13 +1,24 @@
 ##!/usr/bin/env python
-import os, sys
-sys.path.insert(1, os.path.join(sys.path[0], '..'))
+import os
+import sys
 from flask import Flask
-from app import create_app, db
-from app.models import PERMISSION_LIST, User, Permission, Service, ProviderDetails, ServiceSmsSender
+
+sys.path.insert(1, os.path.join(sys.path[0], '..'))
+
+from app import create_app, db  # noqa: E402
+from app.models import (  # noqa: E402
+    PERMISSION_LIST,
+    User,
+    Permission,
+    Service,
+    ProviderDetails,
+    ServiceSmsSender
+)
 
 flask_app = Flask('app')
 app = create_app(flask_app)
-app.app_context().push() # binds SQLAlchemy to our app instance
+app.app_context().push()  # binds SQLAlchemy to our app instance
+
 
 # Add all permissions to the seeded user
 # These permissions are sent to `notifications-admin` app and unlocks all functionality
@@ -15,14 +26,14 @@ user = User.query.filter_by(email_address="notify-service-user@digital.cabinet-o
 service = Service.query.first()
 
 if user and service:
-  existing_permissions = user.get_permissions()[str(service.id)]
+    existing_permissions = user.get_permissions()[str(service.id)]
 
-  for permission_name in PERMISSION_LIST:
-    if permission_name in existing_permissions:
-      continue
-    permission = Permission(user_id=user.id, service_id=service.id, permission=permission_name)
-    db.session.add(permission)
-    db.session.commit()
+    for permission_name in PERMISSION_LIST:
+        if permission_name in existing_permissions:
+            continue
+        permission = Permission(user_id=user.id, service_id=service.id, permission=permission_name)
+        db.session.add(permission)
+        db.session.commit()
 
 
 # SMS Backend Providers: Disable MMG and enable Firetext
@@ -30,22 +41,23 @@ if user and service:
 mmg = ProviderDetails.query.filter_by(identifier='mmg').first()
 firetext = ProviderDetails.query.filter_by(identifier='firetext').first()
 if mmg:
-  mmg.active = False
+    mmg.active = False
 if firetext:
-  firetext.active = True
-db.session.commit()
+    firetext.active = True
+    db.session.commit()
 
 # Disable sending SMS messages as "GOVUK"
 # Trying to send an SMS as "GOVUK" will almost certainly get your SMS account blocked
 # Let's archive the "GOVUK" sender so it won't be used but sticks around for reference
 sender = ServiceSmsSender.query.filter_by(sms_sender='GOVUK').first()
 if sender:
-  sender.archived = True
-  db.session.commit()
+    sender.archived = True
+    db.session.commit()
 
 # Reset the (randomly generated) password for the default user to a known value
 user = User.query.filter_by(email_address="notify-service-user@digital.cabinet-office.gov.uk").first()
 new_password = "hu1aX@UgArA6pZ@*^wQW"
 user.password = new_password
 db.session.commit()
-print("\n\nYou can now login the notifactions-admin app using the following credentials:\nEmail: {}\nPassword: {}".format(user.email_address, new_password))
+print("\n\nYou can now login the notifactions-admin app using the following credentials:")
+print("Email: {}\nPassword: {}".format(user.email_address, new_password))


### PR DESCRIPTION
In a previous commit we introduced a new script,
`apply_dev_defaults.py`, which updates the default seeded database
records to be better suited for local development. After running the
test-suite, multiple stylistic violations have been reported by the
`flake8` tool, causing the CI run to fail during static analysis.

This commit updates the `apply_dev_defaults.py` script to address the
following stylistic concerns:

1) Indent using 4 spaces
2) No single line should be longer than 120 characters
3) Whenever possible, the top of the file should contain only imports.
4) Silenced 2 x warning where `imports` need to exist *after* updating
`sys.path` (regular python code).