### PR TITLE
🐛 Handle case where user has zero permissions

### DIFF
--- a/scripts/apply_dev_defaults.py
+++ b/scripts/apply_dev_defaults.py
@@ -26,7 +26,8 @@ user = User.query.filter_by(email_address="notify-service-user@digital.cabinet-o
 service = Service.query.first()
 
 if user and service:
-    existing_permissions = user.get_permissions()[str(service.id)]
+    permissions_dict = user.get_permissions()
+    existing_permissions = permissions_dict.get(str(service.id), [])
 
     for permission_name in PERMISSION_LIST:
         if permission_name in existing_permissions:


### PR DESCRIPTION
We recently added a new script, `apply_dev_defaults.py`, which, amongst
other things, seed the default user with a full set of permissions.
Whilst running this script on a newly provisioned database, I've
discovered a runtime error where, for a user who has zero permissions,
we'll try to access a python dictionary using a key that doesn't exist:

```
Traceback (most recent call last):
  File "scripts/apply_dev_defaults.py", line 29, in <module>
    existing_permissions = user.get_permissions()[str(service.id)]
KeyError: 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
```

This commit updates the script to get the Python dictionary `get`
method, avoiding the `KeyError` and instead returning a default value.

https://app.asana.com/0/1199707043388412/1199940470983783