### PR TITLE
🔧 Fix & Improve Dev Setup Script

### DIFF
--- a/scripts/apply_dev_defaults.py
+++ b/scripts/apply_dev_defaults.py
@@ -26,7 +26,8 @@ user = User.query.filter_by(email_address="notify-service-user@digital.cabinet-o
 service = Service.query.first()
 
 if user and service:
-    existing_permissions = user.get_permissions()[str(service.id)]
+    permissions_dict = user.get_permissions()
+    existing_permissions = permissions_dict.get(str(service.id), [])
 
     for permission_name in PERMISSION_LIST:
         if permission_name in existing_permissions:

--- a/scripts/apply_dev_defaults.py
+++ b/scripts/apply_dev_defaults.py
@@ -57,6 +57,7 @@ if sender:
 
 # Reset the (randomly generated) password for the default user to a known value
 user = User.query.filter_by(email_address="notify-service-user@digital.cabinet-office.gov.uk").first()
+user.mobile_number = "+447912345678"
 new_password = "hu1aX@UgArA6pZ@*^wQW"
 user.password = new_password
 db.session.commit()


### PR DESCRIPTION
🐛 Handle case where user has zero permissions

We recently added a new script, `apply_dev_defaults.py`, which, amongst
other things, seed the default user with a full set of permissions.
Whilst running this script on a newly provisioned database, I've
discovered a runtime error where, for a user who has zero permissions,
we'll try to access a python dictionary using a key that doesn't exist:

```
Traceback (most recent call last):
File "scripts/apply_dev_defaults.py", line 29, in <module>
existing_permissions = user.get_permissions()[str(service.id)]
KeyError: 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'
```

This commit updates the script to get the Python dictionary `get`
method, avoiding the `KeyError` and instead returning a default value.

https://app.asana.com/0/1199707043388412/1199940470983783

---

☎️ Update seeded user with valid phone number

The default user from `scripts/bootstrap.sh` is seeded with an invalid
mobile phone number. This means, when you login with a username and
password, the API will refuse to dispatch a 2FA code via SMS since the
user's phone number fails validation.

This commit updates our `apply_dev_defaults.py` script, rewriting the
user's phone number to a valid UK format.