### PR TITLE
🔥 Delete (seemingly) nonsensical test

### DIFF
--- a/tests/app/dao/notification_dao/test_notification_dao.py
+++ b/tests/app/dao/notification_dao/test_notification_dao.py
@@ -141,19 +141,6 @@ def test_should_update_status_by_id_and_set_sent_by(sample_template):
     assert updated.sent_by == 'mmg'
 
 
-def test_should_not_update_status_by_reference_if_from_country_with_no_delivery_receipts(sample_template):
-    notification = create_notification(
-        sample_template,
-        status=NOTIFICATION_SENT,
-        reference='foo'
-    )
-
-    res = update_notification_status_by_reference('foo', 'failed')
-
-    assert res is None
-    assert notification.status == NOTIFICATION_SENT
-
-
 def test_should_not_update_status_by_id_if_sent_to_country_with_unknown_delivery_receipts(sample_template):
     notification = create_notification(
         sample_template,


### PR DESCRIPTION
In a recent PR we added support for a new backend SMS provider, Twilio.
As part of this new integrations we needed to update the
`update_notification_status_by_reference` method which, until now, has
only dealt with delivery callbacks for email delivery, hence it would
only process callbacks for emails in the "sending" or "pending" status.

The final delivery state for a Twilio SMS is "delivered", hence we added
support for callbacks about messages in the "sent" state, causing one of
the unit specs in our test-suite to fail.

Based on the test name, it looks like the author was trying to test
delivery notification behaviour for an (international?) message that
doesn't support delivery receipts? The implementation of the test,
however, doesn't seem to relate to the tests name.

This commit removes the problematic test from our test-suite since it's
unclear what's actually been exercised or verified based on the test's
implementation.

https://app.asana.com/0/1199707043388412/1199945098442987