### PR TITLE
🌱 Update DB seeds to provide better defaults for Catalyst Notify

### DIFF
--- a/migrations/versions/0346_change_support_email_address_prefix.py
+++ b/migrations/versions/0346_change_support_email_address_prefix.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 93fdd95e5ed3
+Revises: 0345_move_broadcast_provider
+Create Date: 2021-03-09 12:16:26.045409
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '93fdd95e5ed3'
+down_revision = '0345_move_broadcast_provider'
+
+def upgrade():
+    op.get_bind()
+    op.execute("update services set email_from = 'noreply' where id = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'")
+
+def downgrade():
+    op.get_bind()
+    op.execute("update services set email_from = 'gov.uk.notify' where id = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'")

--- a/migrations/versions/0347_rename_default_service_to_catalyst_notify.py
+++ b/migrations/versions/0347_rename_default_service_to_catalyst_notify.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: e3a56ce85041
+Revises: 93fdd95e5ed3
+Create Date: 2021-03-09 15:44:32.303444
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'e3a56ce85041'
+down_revision = '93fdd95e5ed3'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("update services set name = 'Catalyst Notify' where id = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'")
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("update services set name = 'GOV.UK Notify' where id = 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553'")

--- a/migrations/versions/0348_rename_sms_sender_to_catalyst.py
+++ b/migrations/versions/0348_rename_sms_sender_to_catalyst.py
@@ -1,0 +1,23 @@
+"""
+
+Revision ID: 898696388198
+Revises: e3a56ce85041
+Create Date: 2021-03-09 16:43:20.451832
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '898696388198'
+down_revision = 'e3a56ce85041'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("update service_sms_senders set sms_sender = 'Catalyst' where id = '286d6176-adbe-7ea7-ba26-b7606ee5e2a4'")
+
+
+def downgrade():
+    op.get_bind()
+    op.execute("update service_sms_senders set sms_sender = 'GOVUK' where id = '286d6176-adbe-7ea7-ba26-b7606ee5e2a4'")

--- a/migrations/versions/0349_set_twilio_as_default_enabled_sms_provider.py
+++ b/migrations/versions/0349_set_twilio_as_default_enabled_sms_provider.py
@@ -1,0 +1,27 @@
+"""
+
+Revision ID: 373ca3da3cfe
+Revises: 898696388198
+Create Date: 2021-03-09 16:49:58.504055
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import uuid
+
+revision = '373ca3da3cfe'
+down_revision = '898696388198'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("update provider_details set active = False where identifier = 'mmg'")
+    op.execute("update provider_details set active = False where identifier = 'firetext'")
+    op.execute("INSERT INTO provider_details (id, display_name, identifier, priority, notification_type, version, active) values ('{}', 'Twilio', 'twilio', 10, 'sms', 1, true)".format(str(uuid.uuid4())))
+
+def downgrade():
+    op.get_bind()
+    op.execute("update provider_details set active = True where identifier = 'mmg'")
+    op.execute("update provider_details set active = True where identifier = 'firetext'")
+    op.execute("delete from provider_details where identifier = 'twilio'")

--- a/migrations/versions/0350_add_permissions_to_seeded_user.py
+++ b/migrations/versions/0350_add_permissions_to_seeded_user.py
@@ -1,0 +1,42 @@
+"""
+
+Revision ID: e17533d246ab
+Revises: 373ca3da3cfe
+Create Date: 2021-03-10 12:23:39.706675
+
+"""
+from alembic import op
+from datetime import datetime
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import uuid
+
+revision = 'e17533d246ab'
+down_revision = '373ca3da3cfe'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("update users set platform_admin = True where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'manage_users', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'manage_templates', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'manage_settings', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'send_texts', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'send_emails', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'send_letters', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'manage_api_keys', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("INSERT INTO permissions (id, user_id, service_id, permission, created_at) values ('{}', '6af522d0-2915-4e52-83a3-3690455a5fe6', 'd6aa2c68-a2d9-4437-ab19-3ae8eb202553', 'view_activity', '{}')".format(str(uuid.uuid4()), datetime.utcnow()))
+    op.execute("update users set platform_admin = True where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")
+
+
+def downgrade():
+    op.execute("update users set platform_admin = False where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'manage_users'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'manage_templates'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'manage_settings'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'send_texts'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'send_emails'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'send_letters'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'manage_api_keys'")
+    op.execute("DELETE from permissions where user_id = '6af522d0-2915-4e52-83a3-3690455a5fe6' AND permission = 'view_activity'")
+

--- a/migrations/versions/0351_change_email_address_of_seeded_user.py
+++ b/migrations/versions/0351_change_email_address_of_seeded_user.py
@@ -15,7 +15,8 @@ down_revision = 'e17533d246ab'
 
 
 def upgrade():
-    op.execute("update users set email_address = '{}' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'".format('support@'+os.environ.get('NOTIFY_EMAIL_DOMAIN')))
+    email_address = "support@" + os.environ.get("NOTIFY_EMAIL_DOMAIN", "example.com")
+    op.execute("update users set email_address = '{}' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'".format(email_address))
 
 def downgrade():
     op.execute("update users set email_address = 'notify-service-user@digital.cabinet-office.gov.uk' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")

--- a/migrations/versions/0351_change_email_address_of_seeded_user.py
+++ b/migrations/versions/0351_change_email_address_of_seeded_user.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: 428551b7cf6f
+Revises: e17533d246ab
+Create Date: 2021-03-10 12:45:08.022940
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+import os
+
+revision = '428551b7cf6f'
+down_revision = 'e17533d246ab'
+
+
+def upgrade():
+    op.execute("update users set email_address = '{}' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'".format('support@'+os.environ.get('NOTIFY_EMAIL_DOMAIN')))
+
+def downgrade():
+    op.execute("update users set email_address = 'notify-service-user@digital.cabinet-office.gov.uk' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")

--- a/migrations/versions/0352_set_valid_uk_phone_number_and_toggle_2fa_mode_to_email.py
+++ b/migrations/versions/0352_set_valid_uk_phone_number_and_toggle_2fa_mode_to_email.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 65fa84b9271b
+Revises: 428551b7cf6f
+Create Date: 2021-03-10 13:17:24.647527
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = '65fa84b9271b'
+down_revision = '428551b7cf6f'
+
+
+def upgrade():
+  op.execute("update users set mobile_number = '+447123456789' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")
+  op.execute("update users set auth_type = 'email_auth' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")
+
+def downgrade():
+  op.execute("update users set mobile_number = '+441234123412' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")
+  op.execute("update users set auth_type = 'sms_auth' where id = '6af522d0-2915-4e52-83a3-3690455a5fe6'")


### PR DESCRIPTION
This PR add new database migrations to update the seed data written to
the API database when a Catalyst Notify is first deployed.

The new database migrations make the following changes to the default
seed data, making it easier to get started with the Catalyst Notify
application:

1. Updates the seeded user to have an email address of :support@domain",
where `domain` is read from the `NOTIFY_EMAIL_DOMAIN` environment
variable.

1. Grants the seeded user with full user and admin permissions.

1. Disables "Firetext" and "MMS" SMS providers. Adds "Twilio" as the
default SMS provider since this is (arguably) the simplest service to
get started with.

1. Renames the default SMS sender from "GOVUK" to "Catalyst".

1. Updates the default 2FA email sender from "gov.uk@domain" to
"noreply@domain", where `domain` is read from the `NOTIFY_EMAIL_DOMAIN`
environment variable.

1. Updates the seeded user to have a valid UK mobile number. We also
take the opportunity to switch the user's 2FA mode from SMS to email,
since we've already updated the user's email address to an inbox 
(hopefully) under the administrator's control.