### PR TITLE
✨ Update organisation type choices

### DIFF
--- a/migrations/versions/0353_add_new_organisation_types_for_catalyst_notify.py
+++ b/migrations/versions/0353_add_new_organisation_types_for_catalyst_notify.py
@@ -1,0 +1,24 @@
+"""
+
+Revision ID: ab8ca793786f
+Revises: 65fa84b9271b
+Create Date: 2021-03-11 16:41:34.595043
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'ab8ca793786f'
+down_revision = '65fa84b9271b'
+
+
+def upgrade():
+    op.get_bind()
+    op.execute("INSERT INTO organisation_types (name, annual_free_sms_fragment_limit, is_crown) values ('charity', 25000, 'False')")
+    op.execute("INSERT INTO organisation_types (name, annual_free_sms_fragment_limit, is_crown) values ('community_interest', 25000, 'False')")
+
+def downgrade():
+    op.get_bind()
+    op.execute("DELETE from organisation_types where name = 'charity'")
+    op.execute("DELETE from organisation_types where name = 'community_interest'")


### PR DESCRIPTION
As part of new user registration, applicants must choose the type of
organisation they work for. Until now, these options have all centred
around government organisations, emergency services or the NHS.

This commit introduces a new database migration, adding new (charity
focused) organisation types to the database.