### PR TITLE
✨ Introduce a new `Service.description` column

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -457,6 +457,7 @@ class Service(db.Model, Versioned):
 
     id = db.Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = db.Column(db.String(255), nullable=False, unique=True)
+    description = db.Column(db.Text, nullable=True)
     created_at = db.Column(
         db.DateTime,
         index=False,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -701,6 +701,7 @@ class NotificationsFilterSchema(ma.Schema):
 class ServiceHistorySchema(ma.Schema):
     id = fields.UUID()
     name = fields.String()
+    description = fields.String()
     created_at = fields.DateTime()
     updated_at = fields.DateTime()
     active = fields.Boolean()

--- a/migrations/versions/e12edee68895_add_description_field_to_service_model.py
+++ b/migrations/versions/e12edee68895_add_description_field_to_service_model.py
@@ -1,0 +1,24 @@
+"""
+
+Revision ID: e12edee68895
+Revises: ab8ca793786f
+Create Date: 2021-03-15 09:49:56.835337
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = 'e12edee68895'
+down_revision = 'ab8ca793786f'
+
+
+def upgrade():
+    op.add_column('services', sa.Column('description', sa.Text(), nullable=True))
+    op.add_column('services_history', sa.Column('description', sa.Text(), nullable=True))
+
+
+
+def downgrade():
+    op.drop_column('services_history', 'description')
+    op.drop_column('services', 'description')


### PR DESCRIPTION
This commit adds a new `description` column to the `Service` and
`ServiceHistory` database tables.

A description field has recently been added to the front-end signup
form. Submission of this new field allows Catalyst admins to make a
better informed decision about whether an applicant charity should be
granted access to the Catalyst Notify application.