### PR TITLE
Bumping notifications-utils to 43.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ Mako==1.1.4
 MarkupSafe==1.1.1
 mistune==0.8.4
 monotonic==1.5
-git+git://github.com/bitzesty/notifications-utils@43.9.2
+git+git://github.com/bitzesty/notifications-utils@43.9.3
 orderedset==2.0.3
 packaging==20.9
 phonenumbers==8.12.19


### PR DESCRIPTION
To fix huge logo image problem.
Depends on admin app being deployed with scaled logo.